### PR TITLE
main in example leaves the impression that it is actually used, when it is not

### DIFF
--- a/test/Data/String/StripSpec.hs
+++ b/test/Data/String/StripSpec.hs
@@ -1,11 +1,8 @@
-module Data.String.StripSpec (main, spec) where
+module Data.String.StripSpec (spec) where
 
 import           Test.Hspec
 
 import           Data.String.Strip
-
-main :: IO ()
-main = hspec spec
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
I was replicating the example in some code of mine, and wanting to run a quicktest for more than 100 times, I replace the hspec in the main with hspecWith, only to realize, some time after, that it was having no effect.

I was indeed using the automatic spec discovery, just like the example, but this seems to efectively ignore the main, it only requires the spec (as it is correctly indicated in the manual, as I latter verified). Anyhow, I do believe that including the main in the example may be counter-productive, do you agree?

By the way, is there a way to use custom quicktest (configQuickCheckArgs) with automatic spec discovery that I am missing?
