### PR TITLE
Add Data.String.Strip to other-modules in cabal file

### DIFF
--- a/strip.cabal
+++ b/strip.cabal
@@ -27,6 +27,8 @@ test-suite spec
       test
   main-is:
       Spec.hs
+  other-modules:
+      Data.String.StripSpec
   build-depends:
       base    == 4.*
     , strip


### PR DESCRIPTION
Get rid of the warning:

```
Warning: The following modules should be added to exposed-modules or other-modules in /Users/hongchangwu/dev/hspec-example/strip.cabal:
    - In spec component:
        Data.String.StripSpec
```