### PR TITLE
update resolver - fixes ghc: panic! (the 'impossible' happened)

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-16.27
+resolver: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/15.yaml


### PR DESCRIPTION
Before PR:
```
dewi@DewiJones:~/code/hspec-example$ git clean -xdf; stack clean && stack build && stack test
++ pwd
+ current_dir=/home/dewi/code/hspec-example
+ [[ /home/dewi/code/hspec-example == \/\m\n\t\/\c* ]]
+ /usr/bin/git config alias.clean
++ pwd
+ current_dir=/home/dewi/code/hspec-example
+ [[ /home/dewi/code/hspec-example == \/\m\n\t\/\c* ]]
+ /usr/bin/git clean -xdf
Removing .stack-work/
ghc: panic! (the 'impossible' happened)
  (GHC version 8.8.4 for x86_64-unknown-linux):
        Prelude.chr: bad argument: 3179719811

Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug


Error: [S-6374]
       While building simple Setup.hs (scroll up to its section to see the error) using:
       /home/dewi/.ghcup/ghc/8.8.4/bin/ghc -rtsopts -threaded -clear-package-db -global-package-db -hide-all-packages -package base -main-is StackSetupShim.mainOverride -package Cabal-3.0.1.0 /home/dewi/.stack/setup-exe-src/setup-6HauvNHV.hs /home/dewi/.stack/setup-exe-src/setup-shim-6HauvNHV.h
s -o /home/dewi/.stack/setup-exe-cache/x86_64-linux/tmp-Cabal-simple_6HauvNHV_3.0.1.0_ghc-8.8.4
       Process exited with code: ExitFailure 1
dewi@DewiJones:~/code/hspec-example$
```

After PR

```
dewi@DewiJones:~/code/hspec-example$ git clean -xdf; stack clean && stack build && stack test
++ pwd
+ current_dir=/home/dewi/code/hspec-example
+ [[ /home/dewi/code/hspec-example == \/\m\n\t\/\c* ]]
+ /usr/bin/git config alias.clean
++ pwd
+ current_dir=/home/dewi/code/hspec-example
+ [[ /home/dewi/code/hspec-example == \/\m\n\t\/\c* ]]
+ /usr/bin/git clean -xdf
Removing .stack-work/
strip> configure (lib)
Configuring strip-0.0.0...
strip> build (lib)
Preprocessing library for strip-0.0.0..
Building library for strip-0.0.0..
[1 of 2] Compiling Data.String.Strip
[2 of 2] Compiling Paths_strip
strip> copy/register
Installing library in /home/dewi/code/hspec-example/.stack-work/install/x86_64-linux/fdb32c7b7c739da62caca3e63219c1596537e4e13f77eaff0de1a2dcdcead328/9.4.7/lib/x86_64-linux-ghc-9.4.7/strip-0.0.0-6Tz8jzZ69qVJhQY97t3Ph4
Registering library for strip-0.0.0..
strip-0.0.0: unregistering (dependencies changed)
strip> configure (lib + test)
Configuring strip-0.0.0...
strip> build (lib + test)
Preprocessing library for strip-0.0.0..
Building library for strip-0.0.0..
[1 of 2] Compiling Data.String.Strip
[2 of 2] Compiling Paths_strip
Preprocessing test suite 'spec' for strip-0.0.0..
Building test suite 'spec' for strip-0.0.0..
[1 of 3] Compiling Data.String.StripSpec
[2 of 3] Compiling Main
[3 of 3] Compiling Paths_strip
[4 of 4] Linking .stack-work/dist/x86_64-linux/Cabal-3.8.1.0/build/spec/spec
strip> copy/register
Installing library in /home/dewi/code/hspec-example/.stack-work/install/x86_64-linux/fdb32c7b7c739da62caca3e63219c1596537e4e13f77eaff0de1a2dcdcead328/9.4.7/lib/x86_64-linux-ghc-9.4.7/strip-0.0.0-4tiDDEV2U2E8k0QozdaG86
Registering library for strip-0.0.0..
strip> test (suite: spec)


Data.String.Strip
  strip
    removes leading and trailing whitespace [✔]

Finished in 0.0002 seconds
1 example, 0 failures



strip> Test suite spec passed
Completed 2 action(s).
dewi@DewiJones:~/code/hspec-example$
```